### PR TITLE
Only keep the first row for each day

### DIFF
--- a/recolul/time.py
+++ b/recolul/time.py
@@ -29,6 +29,9 @@ def get_overtime_history(attendance_chart: AttendanceChart) -> tuple[list[str], 
             continue
 
         day = row.day
+        if not day.text:
+            continue
+
         days.append(day.text)
         required_time = Duration(0 if day.color in ["blue", "red"] else 8 * 60)  # No required hours for holidays
         work_time = get_work_time(row)


### PR DESCRIPTION
This avoids messing up with the work time for days where there have been several clock-ins.

![image](https://user-images.githubusercontent.com/29782/221756430-bfe361b4-9459-4466-8f91-0b945c6b28f1.png)
