### PR TITLE
Add configurable hours per day for part-time support

### DIFF
--- a/recolul/cli.py
+++ b/recolul/cli.py
@@ -3,24 +3,24 @@ import sys
 from getpass import getpass
 
 from recolul import __version__, plotting, time
-from recolul.config import Config
+from recolul.config import Config, DEFAULT_HOURS_PER_DAY, DEFAULT_WFH_HOURS_PER_DAY
 from recolul.errors import NoClockInError
 from recolul.recoru.attendance_chart import AttendanceChart
 from recolul.recoru.recoru_session import RecoruSession
 from recolul.time import get_max_wfh_time, get_row_work_time, until_today
 
 
-def balance(exclude_last_day: bool) -> None:
-    full_attendance_chart = _get_attendance_chart()
+def balance(config: Config, exclude_last_day: bool) -> None:
+    full_attendance_chart = _get_attendance_chart(config)
     attendance_chart = until_today(full_attendance_chart)
     if exclude_last_day and len(attendance_chart) > 1:
         attendance_chart = attendance_chart[:-1]
-    overtime_balance, total_workplace_times = time.get_overtime_balance(attendance_chart)
+    overtime_balance, total_workplace_times = time.get_overtime_balance(attendance_chart, config)
     print(f"Monthly overtime balance: {overtime_balance}")
     print(f"Total time per workplace:")
     for workplace, total_work_time in total_workplace_times.items():
         print(f"  {workplace}: {total_work_time}")
-    print(f"Maximum WFH time this month: {get_max_wfh_time(full_attendance_chart)}")
+    print(f"Maximum WFH time this month: {get_max_wfh_time(full_attendance_chart, config)}")
 
     if exclude_last_day:
         return
@@ -28,13 +28,13 @@ def balance(exclude_last_day: bool) -> None:
     last_day = attendance_chart[-1]
     print(f"\nLast day {last_day.day.text}")
     print(f"  Clock-in: {max(entry.clock_in_time for entry in last_day.entries)}")
-    print(f"  Working hours: {get_row_work_time(last_day)}")
+    print(f"  Working hours: {get_row_work_time(last_day, config)}")
 
 
-def when_to_leave() -> None:
+def when_to_leave(config: Config) -> None:
     try:
-        full_attendance_chart = _get_attendance_chart()
-        leave_times = time.get_leave_time(full_attendance_chart)
+        full_attendance_chart = _get_attendance_chart(config)
+        leave_times = time.get_leave_time(full_attendance_chart, config)
     except NoClockInError:
         print("You have already clocked out.")
         return
@@ -61,19 +61,23 @@ def update_config() -> None:
     recoru_contract_id = input("recoru.contractId: ")
     recoru_auth_id = input("recoru.authId: ")
     recoru_password = getpass("recoru.password: ")
+    hours_per_day = input(f"recoru.hoursPerDay [{DEFAULT_HOURS_PER_DAY}]: ") or str(DEFAULT_HOURS_PER_DAY)
+    wfh_hours_per_day = input(f"recoru.wfhHoursPerDay [{DEFAULT_WFH_HOURS_PER_DAY}]: ") or str(DEFAULT_WFH_HOURS_PER_DAY)
     config = Config(
         recoru_contract_id=recoru_contract_id,
         recoru_auth_id=recoru_auth_id,
-        recoru_password=recoru_password
+        recoru_password=recoru_password,
+        hours_per_day=int(hours_per_day),
+        wfh_hours_per_day=float(wfh_hours_per_day),
     )
     config.save()
 
 
-def graph(exclude_last_day: bool) -> None:
-    attendance_chart = until_today(_get_attendance_chart())
+def graph(config: Config, exclude_last_day: bool) -> None:
+    attendance_chart = until_today(_get_attendance_chart(config))
     if exclude_last_day and len(attendance_chart) > 1:
         attendance_chart = attendance_chart[:-1]
-    days, history, _ = time.get_overtime_history(attendance_chart)
+    days, history, _ = time.get_overtime_history(attendance_chart, config)
     plotting.plot_overtime_balance_history(days, history)
 
 
@@ -101,22 +105,24 @@ def main() -> None:
     )
 
     args = parser.parse_args(sys.argv[1:])
-    match args.command:
-        case "balance":
-            balance(exclude_last_day=args.exclude_last_day)
-        case "when":
-            when_to_leave()
-        case "config":
-            update_config()
-        case "graph":
-            graph(exclude_last_day=args.exclude_last_day)
+    if args.command == "config":
+        update_config()
+        return
 
-
-def _get_attendance_chart() -> AttendanceChart:
     config = Config.from_env() or Config.load()
     if not config:
-        raise RuntimeError(f"No config found")
+        raise RuntimeError("No config found")
 
+    match args.command:
+        case "balance":
+            balance(config, exclude_last_day=args.exclude_last_day)
+        case "when":
+            when_to_leave(config)
+        case "graph":
+            graph(config, exclude_last_day=args.exclude_last_day)
+
+
+def _get_attendance_chart(config: Config) -> AttendanceChart:
     with RecoruSession(
         contract_id=config.recoru_contract_id,
         auth_id=config.recoru_auth_id,

--- a/recolul/config.py
+++ b/recolul/config.py
@@ -4,12 +4,17 @@ from dataclasses import dataclass
 
 DEFAULT_CONFIG_PATH = os.path.realpath(f"{__file__}/../config.ini")
 
+DEFAULT_HOURS_PER_DAY = 8
+DEFAULT_WFH_HOURS_PER_DAY = 1.0
+
 
 @dataclass
 class Config:
     recoru_contract_id: str
     recoru_auth_id: str
     recoru_password: str
+    hours_per_day: int = DEFAULT_HOURS_PER_DAY
+    wfh_hours_per_day: float = DEFAULT_WFH_HOURS_PER_DAY
 
     @classmethod
     def from_env(cls):
@@ -17,7 +22,9 @@ class Config:
             return cls(
                 recoru_contract_id=os.environ["RECORU_CONTRACT_ID"],
                 recoru_auth_id=os.getenv("RECORU_AUTH_ID"),
-                recoru_password=os.environ["RECORU_PASSWORD"]
+                recoru_password=os.environ["RECORU_PASSWORD"],
+                hours_per_day=int(os.getenv("RECORU_HOURS_PER_DAY", DEFAULT_HOURS_PER_DAY)),
+                wfh_hours_per_day=float(os.getenv("RECORU_WFH_HOURS_PER_DAY", DEFAULT_WFH_HOURS_PER_DAY)),
             )
         except KeyError:
             return None
@@ -32,7 +39,9 @@ class Config:
         return cls(
             recoru_contract_id=config["recoru"]["contractId"],
             recoru_auth_id=config["recoru"]["authId"],
-            recoru_password=config["recoru"]["password"]
+            recoru_password=config["recoru"]["password"],
+            hours_per_day=int(config["recoru"].get("hoursPerDay", DEFAULT_HOURS_PER_DAY)),
+            wfh_hours_per_day=float(config["recoru"].get("wfhHoursPerDay", DEFAULT_WFH_HOURS_PER_DAY)),
         )
 
     def save(self, path: str = DEFAULT_CONFIG_PATH):
@@ -40,7 +49,9 @@ class Config:
         config["recoru"] = {
             "authId": self.recoru_auth_id,
             "contractId": self.recoru_contract_id,
-            "password": self.recoru_password
+            "password": self.recoru_password,
+            "hoursPerDay": str(self.hours_per_day),
+            "wfhHoursPerDay": str(self.wfh_hours_per_day),
         }
         with open(path, "w") as config_file:
             config.write(config_file)

--- a/recolul/time.py
+++ b/recolul/time.py
@@ -2,6 +2,7 @@ import dataclasses
 from collections import defaultdict
 from datetime import datetime
 
+from recolul.config import Config
 from recolul.duration import Duration
 from recolul.errors import NoClockInError
 from recolul.recoru.attendance_chart import AttendanceChart, ChartRow, ChartRowEntry
@@ -18,22 +19,23 @@ def until_today(attendance_chart: AttendanceChart) -> AttendanceChart:
     ]
 
 
-def get_max_wfh_time(full_attendance_chart: AttendanceChart) -> Duration:
+def get_max_wfh_time(full_attendance_chart: AttendanceChart, config: Config) -> Duration:
     """Returns the total WFH time doable this month"""
-    return Duration(60) * count_working_days(full_attendance_chart)
+    wfh_minutes_per_day = int(config.wfh_hours_per_day * 60)
+    return Duration(wfh_minutes_per_day) * count_working_days(full_attendance_chart)
 
 
-def get_remaining_wfh_time(full_attendance_chart: AttendanceChart):
+def get_remaining_wfh_time(full_attendance_chart: AttendanceChart, config: Config):
     """Returns the remaining WFH hours doable this month"""
-    max_wfh_hours = get_max_wfh_time(full_attendance_chart)
+    max_wfh_hours = get_max_wfh_time(full_attendance_chart, config)
     attendance_chart = until_today(full_attendance_chart)
-    _, total_workplace_times = get_overtime_balance(attendance_chart[:-1])
+    _, total_workplace_times = get_overtime_balance(attendance_chart[:-1], config)
 
     remaining = max_wfh_hours - total_workplace_times.get("WFH", Duration(0))
     return remaining if remaining else Duration(0)
 
 
-def get_entry_work_time(entry: ChartRowEntry) -> Duration:
+def get_entry_work_time(entry: ChartRowEntry, config: Config) -> Duration:
     """
     Get work time from the column if available,
     else calculate it from clock-in time and current time
@@ -42,9 +44,9 @@ def get_entry_work_time(entry: ChartRowEntry) -> Duration:
     if category.startswith(
         ("Half Day Leave", "Flexible Holiday AM", "Flexible Holiday PM")
     ):
-        return Duration(4 * 60)
+        return Duration(config.hours_per_day * 60 // 2)
     if category.endswith(("Leave", "Leagve")) or category == "Flexible Holiday":
-        return Duration(8 * 60)
+        return Duration(config.hours_per_day * 60)
 
     if not (raw_clock_in_time := entry.clock_in_time):
         return Duration(0)
@@ -68,27 +70,29 @@ def get_entry_work_time(entry: ChartRowEntry) -> Duration:
     return work_time - break_time
 
 
-def get_row_work_time(row: ChartRow) -> Duration:
+def get_row_work_time(row: ChartRow, config: Config) -> Duration:
     total_work_time = Duration()
     for entry in row.entries:
-        total_work_time += get_entry_work_time(entry)
+        total_work_time += get_entry_work_time(entry, config)
     return total_work_time
 
 
-def get_overtime_history(attendance_chart: AttendanceChart) -> tuple[list[str], list[Duration], dict[str, Duration]]:
+def get_overtime_history(
+    attendance_chart: AttendanceChart, config: Config
+) -> tuple[list[str], list[Duration], dict[str, Duration]]:
     days = []
     overtime_history = []
     total_workplace_times = defaultdict(Duration)
     for row in attendance_chart:
         day = row.day.text
         if _is_working_day(row) or _is_swap_day(row):
-            required_time = Duration(8 * 60)
+            required_time = Duration(config.hours_per_day * 60)
         else:
             required_time = Duration(0)
 
         row_work_time = Duration()
         for entry in row.entries:
-            entry_work_time = get_entry_work_time(entry)
+            entry_work_time = get_entry_work_time(entry, config)
             row_work_time += entry_work_time
 
             workplace = entry.workplace or "HF Bldg."  # Workplace is empty for paid leaves
@@ -104,8 +108,10 @@ def get_overtime_history(attendance_chart: AttendanceChart) -> tuple[list[str], 
     return days, overtime_history, total_workplace_times
 
 
-def get_overtime_balance(attendance_chart: AttendanceChart) -> tuple[Duration, dict[str, Duration]]:
-    _, history, total_workplace_times = get_overtime_history(attendance_chart)
+def get_overtime_balance(
+    attendance_chart: AttendanceChart, config: Config
+) -> tuple[Duration, dict[str, Duration]]:
+    _, history, total_workplace_times = get_overtime_history(attendance_chart, config)
     return sum(history, Duration()), total_workplace_times
 
 
@@ -118,10 +124,10 @@ class LeaveTime:
     wfh_cutoff_includes_break: bool = False
 
 
-def get_leave_time(full_attendance_chart: AttendanceChart) -> list[LeaveTime]:
+def get_leave_time(full_attendance_chart: AttendanceChart, config: Config) -> list[LeaveTime]:
     attendance_chart = until_today(full_attendance_chart)
-    day_base_hours = Duration(8 * 60)
-    overtime_balance, _ = get_overtime_balance(attendance_chart[:-1])
+    day_base_hours = Duration(config.hours_per_day * 60)
+    overtime_balance, _ = get_overtime_balance(attendance_chart[:-1], config)
 
     last_row = attendance_chart[-1]
     last_clock_in = None
@@ -133,14 +139,14 @@ def get_leave_time(full_attendance_chart: AttendanceChart) -> list[LeaveTime]:
             is_wfh = entry.workplace == "WFH"
         else:
             # Complete entry
-            overtime_balance += get_entry_work_time(entry)
+            overtime_balance += get_entry_work_time(entry, config)
     if not last_clock_in:
         raise NoClockInError()
 
     required_today = day_base_hours - overtime_balance
 
     # When in WFH, the required hours cannot exceed the remaining WFH hours.
-    wfh_remaining_hours = get_remaining_wfh_time(full_attendance_chart)
+    wfh_remaining_hours = get_remaining_wfh_time(full_attendance_chart, config)
     wfh_cutoff_time: Duration | None = None
     wfh_cutoff_includes_break = False
     if is_wfh and wfh_remaining_hours < required_today:

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,11 +1,15 @@
 import os.path
 
+from recolul.config import Config
 from recolul.duration import Duration
 from recolul.recoru.attendance_chart import AttendanceChart
 from recolul.recoru.recoru_session import RecoruSession
 from recolul.time import LeaveTime, get_leave_time, get_overtime_history
 
 RESOURCES_FOLDER = os.path.realpath(f"{__file__}/../resources")
+
+DEFAULT_CONFIG = Config(recoru_contract_id="", recoru_auth_id="", recoru_password="")
+PART_TIME_CONFIG = Config(recoru_contract_id="", recoru_auth_id="", recoru_password="", hours_per_day=6, wfh_hours_per_day=0.5)
 
 
 def load_mock_attendance_chart(filename: str) -> AttendanceChart:
@@ -17,7 +21,7 @@ def test_get_overtime_history_multiple_entry_rows():
     # 8/7: AM WFH, PM in office
     # 8/14: Extra row of WFH
     chart = load_mock_attendance_chart("multiple_entry_rows.html")
-    days, overtime_history, total_workplace_times = get_overtime_history(chart)
+    days, overtime_history, total_workplace_times = get_overtime_history(chart, DEFAULT_CONFIG)
     assert days == ["8/7(月)", "8/8(火)", "8/9(水)", "8/10(木)", "8/14(月)"]
     assert overtime_history == [
         Duration(45),
@@ -37,12 +41,37 @@ def test_get_overtime_history_multiple_entry_rows():
     }
 
 
+def test_get_overtime_history_multiple_entry_rows_part_time():
+    # Same fixture but with 6h/day: required time drops by 2h per day,
+    # so each day gets +120min overtime compared to 8h.
+    chart = load_mock_attendance_chart("multiple_entry_rows.html")
+    days, overtime_history, total_workplace_times = get_overtime_history(chart, PART_TIME_CONFIG)
+    assert days == ["8/7(月)", "8/8(火)", "8/9(水)", "8/10(木)", "8/14(月)"]
+    assert overtime_history == [
+        Duration(45 + 120),
+        Duration(25 + 120),
+        Duration(-48 + 120),
+        Duration.parse("01:31") + Duration(120),
+        -Duration.parse("02:19") + Duration(120),
+    ]
+    # Workplace times unchanged (based on actual clock times, not required hours)
+    assert total_workplace_times == {
+        "HF Bldg.": (
+            Duration.parse("06:58") +
+            Duration.parse("08:25") +
+            Duration.parse("07:12") +
+            Duration.parse("09:31")
+        ),
+        "WFH": Duration.parse("01:47") + Duration.parse("05:26") + Duration(15)
+    }
+
+
 def test_get_overtime_history_no_work_time():
     # 11/22: No work time
     # 11/23: Holiday
     # 11/24: Paid leave
     chart = load_mock_attendance_chart("unworked_wednesday.html")
-    days, overtime_history, total_workplace_times = get_overtime_history(chart)
+    days, overtime_history, total_workplace_times = get_overtime_history(chart, DEFAULT_CONFIG)
     assert days == ["11/20(月)", "11/21(火)", "11/22(水)", "11/24(金)"]
     assert overtime_history == [Duration(14), Duration(8), Duration(-8 * 60), Duration(0)]
     assert total_workplace_times == {
@@ -50,9 +79,27 @@ def test_get_overtime_history_no_work_time():
     }
 
 
+def test_get_overtime_history_no_work_time_part_time():
+    # Same fixture with 6h/day: paid leave credits 6h instead of 8h,
+    # required time per working day drops to 6h.
+    chart = load_mock_attendance_chart("unworked_wednesday.html")
+    days, overtime_history, total_workplace_times = get_overtime_history(chart, PART_TIME_CONFIG)
+    assert days == ["11/20(月)", "11/21(火)", "11/22(水)", "11/24(金)"]
+    assert overtime_history == [
+        Duration(14 + 120),       # 08:14 worked - 06:00 required
+        Duration(8 + 120),        # 08:08 worked - 06:00 required
+        Duration(-6 * 60),        # 0 worked - 06:00 required
+        Duration(0),              # 06:00 paid leave - 06:00 required
+    ]
+    # Paid leave now credits 6h instead of 8h
+    assert total_workplace_times == {
+        "HF Bldg.": Duration.parse("08:14") + Duration.parse("08:08") + Duration.parse("06:00")
+    }
+
+
 def test_get_overtime_history_worked_holiday():
     chart = load_mock_attendance_chart("worked_holiday.html")
-    days, overtime_history, total_workplace_times = get_overtime_history(chart)
+    days, overtime_history, total_workplace_times = get_overtime_history(chart, DEFAULT_CONFIG)
     assert days == ["11/20(月)", "11/21(火)", "11/22(水)", "11/23(木)", "11/24(金)"]
     assert overtime_history == [-Duration(2), Duration(17), Duration(19), Duration.parse("03:23"), Duration(4)]
     assert total_workplace_times == {
@@ -68,7 +115,7 @@ def test_get_overtime_history_worked_holiday():
 
 def test_clock_out_after_midnight():
     chart = load_mock_attendance_chart("clock_out_after_midnight.html")
-    days, overtime_history, total_workplace_times = get_overtime_history(chart)
+    days, overtime_history, total_workplace_times = get_overtime_history(chart, DEFAULT_CONFIG)
     assert days == ["12/1(金)", "12/2(土)", "12/3(日)"]
     assert overtime_history == [Duration.parse("06:11"), Duration.parse("03:00"), Duration.parse("02:17")]
     assert total_workplace_times == {
@@ -79,7 +126,7 @@ def test_clock_out_after_midnight():
 
 def test_leave_time_with_break():
     chart = load_mock_attendance_chart("when_break.html")
-    leave_times = get_leave_time(chart)
+    leave_times = get_leave_time(chart, DEFAULT_CONFIG)
     assert leave_times == [
         LeaveTime(includes_break=True, min_time=Duration.parse("18:31"))
     ]
@@ -87,7 +134,7 @@ def test_leave_time_with_break():
 
 def test_leave_time_no_break():
     chart = load_mock_attendance_chart("when_no_break.html")
-    leave_times = get_leave_time(chart)
+    leave_times = get_leave_time(chart, DEFAULT_CONFIG)
     assert leave_times == [
         LeaveTime(includes_break=False, min_time=Duration.parse("13:39"))
     ]
@@ -95,7 +142,7 @@ def test_leave_time_no_break():
 
 def test_double_leave_time():
     chart = load_mock_attendance_chart("when_double_leave.html")
-    leave_times = get_leave_time(chart)
+    leave_times = get_leave_time(chart, DEFAULT_CONFIG)
     assert leave_times == [
         LeaveTime(
             includes_break=False,
@@ -108,11 +155,39 @@ def test_double_leave_time():
 
 def test_leave_time_wfh_cutoff_time():
     chart = load_mock_attendance_chart("wfh_cutoff_time.html")
-    leave_times = get_leave_time(chart)
+    leave_times = get_leave_time(chart, DEFAULT_CONFIG)
     assert leave_times == [
         LeaveTime(
             includes_break=True,
             min_time=Duration.parse("19:00"),
             wfh_cutoff_time=Duration.parse("12:00"),
         )
+    ]
+
+
+def test_leave_time_with_break_part_time():
+    # With 6h/day, accumulated overtime from prior days is higher,
+    # so required_today drops below 6h and no break is needed.
+    chart = load_mock_attendance_chart("when_break.html")
+    leave_times = get_leave_time(chart, PART_TIME_CONFIG)
+    assert leave_times == [
+        LeaveTime(includes_break=False, min_time=Duration.parse("13:31"))
+    ]
+
+
+def test_leave_time_no_break_part_time():
+    chart = load_mock_attendance_chart("when_no_break.html")
+    leave_times = get_leave_time(chart, PART_TIME_CONFIG)
+    assert leave_times == [
+        LeaveTime(includes_break=False, min_time=Duration.parse("09:39"))
+    ]
+
+
+def test_double_leave_time_part_time():
+    # With 6h/day, enough prior overtime that required_today is well under 5h,
+    # so a single no-break window is sufficient.
+    chart = load_mock_attendance_chart("when_double_leave.html")
+    leave_times = get_leave_time(chart, PART_TIME_CONFIG)
+    assert leave_times == [
+        LeaveTime(includes_break=False, min_time=Duration.parse("10:22"))
     ]


### PR DESCRIPTION
## Summary
- Add `hoursPerDay` and `wfhHoursPerDay` settings to config.ini (and env vars `RECORU_HOURS_PER_DAY`, `RECORU_WFH_HOURS_PER_DAY`)
- All overtime/leave calculations now use the configured hours instead of hardcoded 8h
- Half-day leave scales proportionally (e.g., 3h for 6h/day)
- WFH allowance is independently configurable (e.g., 0.5h/day for part-time)
- Defaults to 8h/day and 1h WFH/day — fully backwards compatible

## Use case
Part-time employees working 6h/day instead of 8h.

## Examples

```
~ recolul balance
Monthly overtime balance: -04:10
Total time per workplace:
  HF Bldg.: 01:50
Maximum WFH time this month: 10:30

Last day 4/1(水)
  Clock-in: 07:47
  Working hours: 01:50
```

First day of the month, looks good enough (exactly 6 hours requires a break):
```
~ recolul when
Leave between 13:47 and 13:47, or after 14:47.
```


## Test plan
- [x] All 7 existing tests pass (default 8h behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)